### PR TITLE
ci: bump release actions to latest (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,15 +32,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload artifact (Linux/Windows)
         if: matrix.os != 'macos-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.name }}
           path: build/bin/krokodyl${{ matrix.ext }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload artifact (macOS)
         if: matrix.os == 'macos-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.name }}
           path: build/bin/krokodyl-macos-universal.zip
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -136,7 +136,7 @@ jobs:
           fi
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: release/*
           generate_release_notes: true


### PR DESCRIPTION
Update GitHub Actions to their current majors so they run on the Node 24 runtime and stop emitting the Node 20 deprecation warning: checkout v4->v6, setup-go v5->v6, setup-node v4->v6, upload-artifact v4->v7, download-artifact v4->v8, action-gh-release v2->v3.