### PR TITLE
fix: address go-review findings (pipe leaks, path-sweep guard, locking)

### DIFF
--- a/app.go
+++ b/app.go
@@ -191,10 +191,14 @@ func (a *App) SetNearbyVisible(visible bool) {
 		}
 	}
 
-	if a.stopDiscovery == nil || a.nearby == nil {
+	// Guard the nearby fields: this runs on a frontend-call goroutine while
+	// shutdown may touch the same fields on another.
+	a.mu.Lock()
+	stop := a.stopDiscovery
+	if stop == nil || a.nearby == nil {
+		a.mu.Unlock()
 		return
 	}
-	a.stopDiscovery()
 	// Becoming visible again bumps the generation so peers that still hold a
 	// goodbye-suppression window for us accept the return announcement
 	// immediately instead of waiting it out.
@@ -202,7 +206,15 @@ func (a *App) SetNearbyVisible(visible bool) {
 		a.nearbyGen++
 		a.nearbyIdentity.Gen = a.nearbyGen
 	}
-	a.stopDiscovery = startDiscovery(a.nearbyIdentity, a.nearby, a.nearbyEmitState, visible)
+	identity, nearby, emitState := a.nearbyIdentity, a.nearby, a.nearbyEmitState
+	a.mu.Unlock()
+
+	stop()
+	newStop := startDiscovery(identity, nearby, emitState, visible)
+
+	a.mu.Lock()
+	a.stopDiscovery = newStop
+	a.mu.Unlock()
 }
 
 // rememberLastPeer persists the most recent zero-code target, best-effort.
@@ -388,11 +400,15 @@ func (a *App) popCancel(id string) (chan struct{}, bool) {
 // shutdown kills live transfer workers so closing the app never leaves
 // orphan processes or blocked transfers behind.
 func (a *App) shutdown(_ context.Context) {
-	if a.stopDiscovery != nil {
-		a.stopDiscovery()
+	a.mu.Lock()
+	stop := a.stopDiscovery
+	srv := a.nearbySrv
+	a.mu.Unlock()
+	if stop != nil {
+		stop()
 	}
-	if a.nearbySrv != nil {
-		a.nearbySrv.close()
+	if srv != nil {
+		srv.close()
 	}
 
 	a.mu.Lock()
@@ -634,16 +650,6 @@ func (a *App) runSendAttempt(id string, job workerJob, grace time.Duration, base
 	return peak, workerErrMsg, err
 }
 
-// overallProgress maps a worker's per-session percent into the band above the
-// progress already achieved, capped at 99 (only completion shows 100).
-func overallProgress(basePct, sessionPct int) int {
-	display := basePct + sessionPct
-	if display > 99 {
-		return 99
-	}
-	return display
-}
-
 func (a *App) ReceiveFile(code, destinationPath string) (string, error) {
 	return a.startReceive(code, destinationPath, "")
 }
@@ -744,7 +750,9 @@ func (a *App) runReceiveAttempt(id string, job workerJob, grace time.Duration, b
 // cleanupStaging removes a staging dir and stops tracking it as a resumable
 // partial. Used when a transfer completes or is cancelled (not when it drops).
 func (a *App) cleanupStaging(stagingDir string) {
-	os.RemoveAll(stagingDir)
+	if err := os.RemoveAll(stagingDir); err != nil {
+		logrus.WithError(err).Warnf("could not remove staging dir %s", stagingDir)
+	}
 	if sp, err := settingsPath(); err == nil {
 		forgetPartial(sp, stagingDir)
 	}
@@ -932,8 +940,10 @@ func (a *App) startStallWatchdog(id string, tracker *stallTracker, connectGrace 
 
 // sleepOrCancel waits d, returning false if the transfer is cancelled first.
 func (a *App) sleepOrCancel(cancelCh chan struct{}, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
 	select {
-	case <-time.After(d):
+	case <-t.C:
 		return true
 	case <-cancelCh:
 		return false
@@ -1008,10 +1018,13 @@ func (a *App) runWorkerJob(id string, job workerJob, onEvent func(workerEvent)) 
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
+		stdin.Close()
 		return "failed to start transfer worker", err
 	}
 
 	if err := cmd.Start(); err != nil {
+		stdin.Close()
+		stdout.Close()
 		return "failed to start transfer worker", err
 	}
 

--- a/discovery.go
+++ b/discovery.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -121,7 +122,9 @@ func decodeIdentity(payload []byte) (discoveryIdentity, error) {
 		}
 	}
 	if len(id.Name) > maxPeerNameLen {
-		id.Name = id.Name[:maxPeerNameLen]
+		// Truncate on a rune boundary so a clamped multi-byte name never
+		// becomes invalid UTF-8 when re-encoded to the frontend.
+		id.Name = strings.ToValidUTF8(id.Name[:maxPeerNameLen], "")
 	}
 	if id.Name == "" {
 		id.Name = "unknown device"

--- a/history.go
+++ b/history.go
@@ -59,7 +59,9 @@ func saveHistory(path string, transfers []FileTransfer) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o644)
+	// 0o600: history may hold resume codes (one-time transfer secrets), so
+	// keep it readable only by the owner.
+	return os.WriteFile(path, data, 0o600)
 }
 
 // clearHistory removes the persisted history. A missing file is already a

--- a/nearby.go
+++ b/nearby.go
@@ -214,10 +214,12 @@ func (s *nearbyServer) handle(conn net.Conn) {
 	})
 
 	accepted := false
+	promptTimer := time.NewTimer(offerPromptTimeout)
 	select {
 	case accepted = <-ch:
-	case <-time.After(offerPromptTimeout):
+	case <-promptTimer.C:
 	}
+	promptTimer.Stop()
 
 	if err := enc.Encode(offerAnswer{Accepted: accepted}); err != nil {
 		return

--- a/recovery.go
+++ b/recovery.go
@@ -49,7 +49,18 @@ func (b *recoveryBudget) record(attemptPeakPct int) (giveUp bool) {
 		return false
 	}
 	b.noProgress++
-	return b.noProgress > b.maxNoProgress
+	return b.noProgress >= b.maxNoProgress
+}
+
+// overallProgress maps a worker's per-session percent into the band above the
+// progress already achieved, capped at 99 (only completion shows 100). Lives
+// here with the rest of the recovery math.
+func overallProgress(basePct, sessionPct int) int {
+	display := basePct + sessionPct
+	if display > 99 {
+		return 99
+	}
+	return display
 }
 
 // recoveryBackoff grows the wait between attempts and caps it, so a hard-down

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -11,14 +11,16 @@ func TestRecoveryBudgetGivesUpAfterNoProgress(t *testing.T) {
 	if b.record(30) {
 		t.Fatal("first progress must not give up")
 	}
-	// Then it stalls at the same 30% — no forward movement.
-	for i := 0; i < maxNoProgressAttempts; i++ {
+	// Then it stalls at the same 30% — no forward movement. The first
+	// maxNoProgressAttempts-1 no-progress attempts keep going.
+	for i := 0; i < maxNoProgressAttempts-1; i++ {
 		if b.record(30) {
 			t.Fatalf("gave up too early at no-progress attempt %d", i)
 		}
 	}
+	// The maxNoProgressAttempts-th no-progress attempt gives up.
 	if !b.record(30) {
-		t.Error("should give up after exceeding the no-progress budget")
+		t.Error("should give up once the no-progress budget is reached")
 	}
 }
 

--- a/settings.go
+++ b/settings.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -130,6 +131,12 @@ func sweepPartials(path string, nowUnix int64) {
 		return
 	}
 	for _, r := range expired {
+		// Defence in depth: only ever delete our own partial directories,
+		// never an arbitrary path a tampered settings file might contain.
+		if !strings.HasPrefix(filepath.Base(r.Dir), partialDirPrefix) {
+			logrus.Warnf("skipping sweep of unexpected partial path: %s", r.Dir)
+			continue
+		}
 		if err := os.RemoveAll(r.Dir); err != nil {
 			logrus.WithError(err).Warnf("could not remove stale partial %s", r.Dir)
 		}

--- a/settings_test.go
+++ b/settings_test.go
@@ -146,6 +146,27 @@ func TestSweepPartialsRemovesStaleDirs(t *testing.T) {
 	}
 }
 
+func TestSweepPartialsRefusesNonPartialPath(t *testing.T) {
+	base := t.TempDir()
+	path := filepath.Join(base, "settings.json")
+
+	// A tampered settings entry pointing at a non-partial directory must
+	// never be deleted, even when expired.
+	precious := filepath.Join(base, "important-data")
+	if err := os.MkdirAll(precious, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := int64(2_000_000)
+	recordPartial(path, precious, now-partialMaxAge-100)
+
+	sweepPartials(path, now)
+
+	if _, err := os.Stat(precious); err != nil {
+		t.Error("sweep must not delete a path that is not a krokodyl partial dir")
+	}
+}
+
 func TestLoadSettingsMissingFileReturnsZero(t *testing.T) {
 	out := loadSettings(filepath.Join(t.TempDir(), "nope.json"))
 	if out.LastDestination != "" {

--- a/staging.go
+++ b/staging.go
@@ -13,6 +13,10 @@ import (
 	"time"
 )
 
+// partialDirPrefix marks krokodyl's staging directories so cleanup can never
+// touch anything else.
+const partialDirPrefix = ".krokodyl-partial-"
+
 // stagingDirForCode derives a deterministic staging directory from the
 // transfer code, inside the destination (kept on the same volume so the final
 // rename never crosses devices). Deterministic-per-code is what makes resume
@@ -21,7 +25,7 @@ import (
 // leaks the shared secret.
 func stagingDirForCode(destinationPath, code string) string {
 	sum := sha256.Sum256([]byte(code))
-	return filepath.Join(destinationPath, ".krokodyl-partial-"+hex.EncodeToString(sum[:8]))
+	return filepath.Join(destinationPath, partialDirPrefix+hex.EncodeToString(sum[:8]))
 }
 
 // stagedFile describes one received file inside a staging directory,


### PR DESCRIPTION
From a Go review of the resilience work:

- runWorkerJob: close stdin/stdout pipes on StdoutPipe/Start failure (fd leak per failed spawn).
- sweepPartials: only os.RemoveAll directories that carry the krokodyl partial prefix, so a tampered settings file can't point cleanup at an arbitrary path. Shared partialDirPrefix const.
- SetNearbyVisible/shutdown: guard the nearby fields (stopDiscovery, nearbyIdentity, nearbyGen, nearbySrv) with a.mu — they were written/read across frontend-call and shutdown goroutines.
- recoveryBudget.record: give up at >= the no-progress budget (was off by one vs the documented 5).
- sleepOrCancel + offer-prompt wait: use time.NewTimer+Stop instead of time.After so pending timers don't linger.
- cleanupStaging: log the RemoveAll error instead of swallowing it.
- decodeIdentity: clamp the peer name on a rune boundary (ToValidUTF8) so a truncated multi-byte name can't become invalid UTF-8.
- history.json written 0o600 (may hold resume codes).
- overallProgress moved to recovery.go beside the rest of the recovery math.

Cancel ordering already sets terminal status before killing the worker, so the reviewed cancel-vs-recovery race can't keep retrying; the idling worker is bounded by the connect grace.