### PR TITLE
docs: contributor onboarding — CLAUDE.md, codemaps, README refresh

### DIFF
--- a/.claude/skills/krokodyl-patterns/SKILL.md
+++ b/.claude/skills/krokodyl-patterns/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: krokodyl-patterns
+description: Repo workflows for krokodyl (Wails + Go + Svelte 5). Use when adding a backend method exposed to the frontend, editing UI strings, changing package deps, writing Go transfer logic, or committing/releasing — encodes the file co-change rules git history shows always move together.
+version: 1.0.0
+source: local-git-analysis
+analyzed_commits: 68
+---
+
+# krokodyl Patterns
+
+Wails v2 desktop app: Go `package main` (flat, at repo root) + `frontend/` (Svelte 5 + Vite). Patterns below are derived from git co-change history — these files **move together**; changing one without the others is the common mistake.
+
+## Commit Conventions
+
+Going-forward standard is **conventional commits**: `feat:`/`fix:`/`refactor:`/`docs:`/`test:`/`chore:`/`perf:`/`ci:`. (Older history is freeform — do not imitate it.) Subject imperative, lower-case, no trailing period.
+
+## Code Architecture
+
+```
+*.go                  # package main, flat at root (app.go, worker.go, recovery.go, …)
+*_test.go             # one test sibling per source file (table-driven, run -race)
+cmd/guiharness/       # GUI-subsystem stderr-bug repro harness
+frontend/src/         # App.svelte (hub), components/, stores/, locales/, i18n.ts
+frontend/wailsjs/     # GENERATED Go↔TS bindings — never hand-edit
+docs/CODEMAPS/        # token-lean architecture maps (read first)
+```
+Churn hubs: `app.go` (~1190 LOC) and `frontend/src/App.svelte` (~1600 LOC). Both exceed the 800-line guideline — extract when touched.
+
+## Workflows (co-change rules)
+
+### Add / change a Go method exposed to the frontend
+History: `app.go` → `wailsjs/go/main/App.js` + `App.d.ts` + `models.ts` always change together.
+1. Edit the `App` method (or exposed struct) in `app.go` (or transfers.go).
+2. Regenerate bindings (`wails dev` / `wails build` runs the generator) — **never hand-edit `wailsjs/`**.
+3. Import + call the new binding in `App.svelte`; consume any new `EventsOn` event.
+
+### Add or edit a UI string
+History: all six `frontend/src/locales/{en,nl,fr,es,hu,zh}.json` change as a set.
+1. Add the key to **every** locale file (en is source of truth; translate the rest).
+2. Reference via `$_('key')` (svelte-i18n); use `{ values: { … } }` for interpolation.
+
+### Change frontend dependencies
+History: `frontend/package.json` co-changes with `frontend/package.json.md5` (+ `package-lock.json`).
+1. Edit `package.json`, run `npm install` (refreshes lockfile).
+2. The `package.json.md5` checksum (Wails `frontend:install` cache key) updates — commit it too, or `wails build` re-installs every time.
+
+### Write Go transfer / resilience logic
+1. Add code to the relevant file (recovery.go, stall.go, worker.go, …).
+2. Add/extend its `*_test.go` sibling (table-driven).
+3. `go test -race ./...` (full gate) or `go test -race <file>_test.go <file>.go` (single subsystem).
+4. `gofmt -w . && go vet ./...` before commit.
+
+### New interactive UI (a11y baseline)
+Needs `aria-label`, the global `:focus-visible`, ≥24px target. Modals use the `modalDialog` action; tabs use roving `tabindex` (container keydown trips `svelte-check`). Verify: `cd frontend && npm run check` → 0 warnings.
+
+### Release
+Merge branch to `main` (PR) → tag main HEAD `git tag -a vX.Y.Z <sha> -F -` → `git push origin vX.Y.Z` (triggers Actions build+publish). Patch-bump from last tag. Keep the Wails CLI pin in `release.yml` in sync with `wails/v2` in `go.mod`.
+
+## Testing Patterns
+
+- Framework: stdlib `go test`, table-driven, **always `-race`**.
+- Layout: one `_test.go` per source file in `package main` (no separate test dir).
+- Frontend gate: `svelte-check` (`npm run check`) for type + a11y; expect 0/0.
+- Manual: nearby/transfer features need **two real machines** (loopback hides cross-net / room-not-ready / virtual-adapter bugs) and the **GUI-launched** binary (terminal stderr hides the Windows GUI-subsystem stall).

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ frontend/dist
 
 # stray local build artifact
 /krokodyl.exe
+
+# personal, machine-specific Claude context
+.claude.local.md

--- a/.reports/codemap-diff.txt
+++ b/.reports/codemap-diff.txt
@@ -1,0 +1,34 @@
+codemap scan — 2026-06-12
+=========================
+mode: INITIAL (no prior codemaps; diff = 100% new, no approval gate triggered)
+
+generated:
+  docs/CODEMAPS/architecture.md   ~750 tok
+  docs/CODEMAPS/backend.md        ~850 tok
+  docs/CODEMAPS/frontend.md       ~700 tok
+  docs/CODEMAPS/data.md           ~650 tok
+  docs/CODEMAPS/dependencies.md   ~550 tok
+
+scanned:
+  Go (package main, non-test): 14 files / 3319 LOC  (app.go 1187 dominant)
+  Go tests:                    ~13 _test.go
+  frontend/src:                17 files (App.svelte 1602 LOC, 6 locales)
+  frontend/wailsjs:            6 GENERATED files
+
+architecture notes:
+  - project type: single Wails v2 desktop app (Go + Svelte 5), one binary / two modes
+  - no HTTP routes, no DB → codemaps adapted: Wails App methods + worker/discovery protocols + JSON-file state
+  - 19 Wails-bound App methods; 6 frontend-subscribed runtime events
+  - subsystems: entry/dispatch · worker subprocess · resilience(recovery/stall) · transfer state · resume staging · LAN discovery(multicast+TLS) · persistence
+
+new dependencies detected (vs none prior):
+  go: wails/v2 v2.12.0, croc/v10 v10.4.4, peerdiscovery v1.7.6, logrus v1.9.4, uuid v1.6.0
+  npm: svelte 5.36.7, vite 6.3.5, svelte-i18n 4.0.1, svelte-check 4.3.0, typescript 5.9.3
+
+staleness: n/a (first generation)
+
+watch-list (high-churn / fragile):
+  - app.go (1187 LOC) — orchestration hub; consider splitting if it grows
+  - App.svelte (1602 LOC) — monolithic UI; component extraction candidate
+  - stagingDirForCode — deterministic, no version field → any change orphans partials
+  - .github/workflows/release.yml Wails pin must track go.mod (v2.12.0)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+krokodyl is a Wails v2 desktop app (Go + Svelte 5) for AirDrop-style P2P file transfer over the croc protocol.
+
+**Read `docs/CODEMAPS/*.md` first** — token-lean architecture/backend/frontend/data/dependency maps.
+
+## Commands
+
+```bash
+wails dev                                   # dev w/ hot reload (Vite + Go); browser debug at http://localhost:34115
+wails build                                 # production build → build/bin/krokodyl(.exe)
+wails build -platform linux/amd64 -tags webkit2_41   # Linux MUST pass this tag (needs libwebkit2gtk-4.1-dev)
+
+go test -race ./...                         # full test gate — every subsystem has a _test.go sibling
+go test -race -run TestName ./...           # single test
+go test -race recovery_test.go recovery.go  # single subsystem (package main, files compiled together)
+
+cd frontend && npm install                  # frontend deps
+cd frontend && npm run check                # svelte-check — TYPE + A11Y gate; expect 0 errors / 0 warnings
+cd frontend && npm run build                # frontend-only build
+
+gofmt -w . && go vet ./...                  # format + static-check gate (run before commit / go-review)
+
+go build -ldflags "-X main.buildStamp=<hash>"   # inject build identifier (default "dev")
+go run . --transfer-worker                  # run a transfer worker standalone (reads one JSON job on stdin) — debugging aid
+```
+
+**Release:** merge the branch to `main` (PR), then tag main HEAD and push — `git tag -a vX.Y.Z <sha> -F -` then `git push origin vX.Y.Z` — which triggers the Actions build (Linux/Windows/macOS) + publish. Patch-bump from the last tag (v0.17.1 → v0.17.2). The Wails CLI version in `.github/workflows/release.yml` (`@v2.12.0`) MUST match `wails/v2` in `go.mod`.
+
+## Architecture (big picture)
+
+**One binary, two modes.** `main.go` checks `--transfer-worker` in `os.Args` *before* `wails.Run()`. Present → `runWorker()` (worker.go) runs one transfer and exits; absent → GUI starts. The flag check must stay before Wails init — Wails owns the main loop and never returns.
+
+**Transfer = child subprocess** (`runWorkerJob` in app.go). The GUI spawns the same binary with `--transfer-worker`, writes a JSON `workerJob` to stdin (closed immediately), and reads JSON `workerEvent` lines from stdout (`files`/`progress`/`done`/`error`). Three reasons for the subprocess model:
+- **Kill-based cancel** — croc has no cancel API; `CancelTransfer` → `cmd.Process.Kill()`.
+- **cwd isolation** — croc writes to cwd; each receive worker does `os.Chdir(stagingDir)`. The GUI never changes its own cwd.
+- **Crash isolation** — a croc segfault kills only that transfer, not the GUI.
+
+**Resilience layer** (recovery.go, stall.go). `runRecoverableAttempts` retries failed workers with backoff (doubling, capped 10s) under a *recovery budget* keyed on peak progress %: if no new peak across N attempts, give up. The stall watchdog (`startStallWatchdog`) is **kill-only** — it kills the stuck worker and lets the recovery loop interpret the resulting error; it never marks the transfer failed itself. `overallProgress(basePct, sessionPct)` offsets per-session worker progress so the bar doesn't reset to 0% on resume. Resume works because `stagingDirForCode` derives a *deterministic* staging dir from the transfer code + croc pre-allocation / `MissingChunks`.
+
+**transferManager** (transfers.go) — mutex-guarded map, emits *copies* of `FileTransfer` (UI can't corrupt live state), terminal states are immutable (late worker events can't resurrect a cancelled/failed transfer), order is newest-first.
+
+**LAN discovery** (discovery.go, nearby.go, netaddr.go, names.go). `schollz/peerdiscovery` multicast on **:42791** advertises id/name/control-port/cert-fingerprint/addresses every 2s (5s expiry, self-echo health check). nearby.go runs an ephemeral TLS control channel (self-signed ECDSA cert, **SHA-256 fingerprint pinning** against the multicast payload) carrying offer → accept/decline → croc-code handoff. netaddr.go ranks real LANs (192.168/10.x) above virtual adapters (172.16 / Hyper-V / WSL / Docker); sender tries candidates real-LAN-first with a 4s per-address timeout. Hide/unhide uses a `Gen` counter + a 3s bye-suppression window so a deliberate unhide is instant while stray re-announces are absorbed. names.go makes random "Adjective Animal" instance names via crypto/rand.
+
+**Persistence** (settings.go, history.go). `settings.json` + `history.json` in the OS config dir, mode `0o600`. A stable per-install `MachineID` (UUID) lets the resend feature re-target the same device across renames. History caps at 50 terminal entries with transfer codes stripped. `historyMu` serializes disk writes; `sweepPartials` only deletes dirs whose basename starts with `partialDirPrefix` (defense against tampered settings).
+
+**Frontend** (frontend/src). Svelte 5 **runes** (`$state`/`$derived`) — most UI lives in one large `App.svelte`. Backend calls go through generated `wailsjs/` bindings; live updates arrive via `EventsOn` (`transfer:updated`, `transfer:overwrite`, `nearby:updated`, `nearby:state`, `nearby:offer`, `transfer:cleared`). svelte-i18n with 6 locales (en/nl/fr/es/hu/zh), theme store persisted to localStorage, `TitleBar.svelte` renders native Windows chrome + macOS traffic-light padding.
+
+## Frontend conventions
+
+- A11y is a maintained baseline (WCAG 2.1 AA). New interactive UI needs an `aria-label`, inherits the global `:focus-visible`, and ≥24px target size.
+- Modals use the `modalDialog` Svelte action (focus-trap + Escape + focus-restore) in App.svelte.
+- Tabs/segmented controls use roving `tabindex` on the items — a keydown handler on the `role=tablist` container trips `svelte-check` (`a11y_interactive_supports_focus`).
+- White-on-green text uses `--color-primary-strong`, not `--color-primary` (contrast).
+
+## Gotchas & constraints
+
+- **No Apple notarization — hard constraint** (no Apple Developer account). macOS ships ad-hoc codesigned (`codesign --sign -`); users right-click → Open once. Don't add notarization steps.
+- **Windows GUI-subsystem stderr is invalid.** A `-H windowsgui` binary launched by double-click has a dead stderr handle; if a worker inherits it, croc's progress writes fail and stall the transfer. Worker `cmd.Stderr` MUST stay `nil`; the parent logs to a file via `bestEffortWriter`. **Terminal-launched runs have a valid stderr and hide this bug** — verify transfer changes by launching the built GUI, not `go run`. `cmd/guiharness` reproduces the exact scenario.
+- **Test nearby/transfer on TWO real machines.** Loopback / single-instance testing misses cross-network, "room not ready", and virtual-adapter (Hyper-V VM↔host) failures.
+- **`wailsjs/` is generated — never hand-edit.** Re-run the Wails generator when a Go struct exposed to the frontend changes.
+- **`stagingDirForCode` determinism is load-bearing.** Changing its hash/salt orphans every in-flight partial transfer; there is no version field, so any change is breaking.
+- **Linux build without `-tags webkit2_41`** builds against WebKit 4.0 and fails at runtime.
+- **`app.go` (~1190) and `App.svelte` (~1600) exceed the 800-line guideline** — extract when you touch them, don't keep growing them.
+
+## Working in this repo (environment)
+
+- **CI occasionally fails on a transient `sum.golang.org` TLS timeout** — that's a flake, not a code break; re-run the job.
+- Commit subjects use conventional prefixes: `feat`/`fix`/`refactor`/`docs`/`test`/`chore`/`perf`/`ci`.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 <img src="build/appicon.png" alt="krokodyl icon" width="128"/>
 
-## Project Overview
+# krokodyl
 
-This is a Wails application called "krokodyl" that provides a desktop GUI for peer-to-peer file transfers using the croc protocol. The application is built with:
+A small, AirDrop-style **peer-to-peer file transfer** desktop app. Drop files, share a code (or just pick a nearby device), and they move directly between machines over the [croc](https://github.com/schollz/croc) protocol — LAN or across the internet, encrypted end-to-end. No account, no cloud, no size limit.
 
-- **Backend**: Go with Wails v2 framework
-- **Frontend**: Svelte with TypeScript and Vite
-- **File Transfer**: Uses the croc library (github.com/schollz/croc/v10) for secure P2P file transfers
+- **Backend:** Go + [Wails v2](https://wails.io)
+- **Frontend:** Svelte 5 (runes) + TypeScript + Vite
+- **Transport:** `github.com/schollz/croc/v10` (PAKE-secured P2P)
+
+## Features
+
+- **Code transfer** — share a short human code; works on the same LAN or across networks.
+- **Nearby devices** — AirDrop-style discovery on the local network; send with no code, just pick a device (TLS control channel with certificate-fingerprint pinning).
+- **Resilient transfers** — survives Wi-Fi drops: stall detection, auto-reconnect, and **resume from where it left off** (the progress bar continues instead of restarting).
+- **Big files** — streamed and chunked; no practical size cap.
+- **Resend** — repeat a past transfer to the same device in one click (remembers the device even if it renamed).
+- **Native shell** — platform window chrome, light/dark themes, 6 languages (en/nl/fr/es/hu/zh), and a WCAG 2.1 AA accessible UI.
+- **Cross-platform** — Windows, macOS (universal), Linux.
 
 ## Installation
 
@@ -35,76 +45,71 @@ If something goes wrong, the app writes a log you can attach to a bug report:
 - Windows: `%LOCALAPPDATA%\krokodyl\krokodyl.log`
 - Linux: `~/.cache/krokodyl/krokodyl.log`
 
-## Architecture
+## Development
 
-The application follows a typical Wails structure:
+### Prerequisites
 
-- `main.go` - Entry point that initializes the Wails application
-- `app.go` - Core application logic with file transfer functionality
-- `frontend/` - Svelte TypeScript frontend
-- `wails.json` - Wails configuration file
+- **Go** 1.25+
+- **Node.js** 22+
+- **Wails CLI** v2.12.0 — `go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0` (keep in sync with `go.mod`)
+- **Linux only:** `gcc libgtk-3-dev libwebkit2gtk-4.1-dev`
+- Check your toolchain with `wails doctor`
 
-### Key Components
+### Run & build
 
-**Go Backend (`app.go`):**
-- `App` struct manages file transfers and application state
-- `FileTransfer` struct represents transfer operations with status tracking
-- Main methods: `SendFile()`, `ReceiveFile()`, `SelectFile()`, `SelectDirectory()`
-- Uses croc protocol with relay servers for secure P2P transfers
-- Emits events to frontend for real-time progress updates
-
-**Frontend (`frontend/`):**
-- Svelte 3 with TypeScript
-- Vite as build tool
-- Communicates with Go backend through Wails bindings
-
-## Development Commands
-
-### Running the Application
 ```bash
-wails dev
-```
-This starts the development server with hot reload. A dev server runs on http://localhost:34115 for browser-based development.
+wails dev          # hot-reload dev (Go + Vite); browser debug at http://localhost:34115
+wails build        # production build → build/bin/krokodyl(.exe)
 
-### Building
-```bash
-wails build
-```
-Creates a production build of the application.
-
-### Frontend Development
-```bash
-cd frontend
-npm install          # Install dependencies
-npm run dev          # Start Vite dev server
-npm run build        # Build frontend
-npm run preview      # Preview built frontend
-npm run check        # Run svelte-check for TypeScript validation
+# Linux MUST pass the webkit tag (links libwebkit2gtk-4.1, not 4.0):
+wails build -platform linux/amd64 -tags webkit2_41
 ```
 
-### Go Development
+### Test & check
+
 ```bash
-go mod tidy          # Clean up Go dependencies
-go build             # Build Go binary
+go test -race ./...                          # full Go test gate (every source file has a _test.go sibling)
+go test -race -run TestName ./...            # a single test
+gofmt -w . && go vet ./...                   # format + static analysis
+
+cd frontend && npm install && npm run check  # svelte-check: TypeScript + accessibility gate (expect 0/0)
 ```
 
-## File Transfer Flow
+> Nearby-device and transfer features need **two real machines** to test properly — loopback/single-instance hides cross-network, "room not ready", and virtual-adapter (VM↔host) bugs. On Windows, test the **built GUI**, not `go run` (a terminal masks a GUI-subsystem stderr bug).
 
-1. **Sending**: User selects file → App creates transfer record → Uses croc to send via relay servers → Generates shareable code
-2. **Receiving**: User enters code and selects destination → App uses croc to receive files → Updates transfer status
+### Project layout
 
-Transfer statuses: preparing → sending/receiving → completed/error
-
-## Testing
-
-No specific test commands are configured in the project. Use standard Go testing:
-```bash
-go test ./...
 ```
+*.go                  # Go backend, package main, flat at repo root
+  main.go             #   entry; dispatches GUI vs --transfer-worker child process
+  app.go              #   GUI orchestration + Wails-bound API
+  worker.go           #   per-transfer subprocess (one croc transfer, then exits)
+  recovery.go stall.go#   retry/resume + stall watchdog
+  discovery.go nearby.go netaddr.go names.go   # LAN discovery + nearby send
+  settings.go history.go staging.go transfers.go
+frontend/src/         # Svelte 5 app (App.svelte is the hub)
+frontend/wailsjs/      # GENERATED Go↔TS bindings — do not hand-edit
+docs/CODEMAPS/        # token-lean architecture maps — start here
+CLAUDE.md             # contributor guide / conventions
+```
+
+For architecture depth, read [`docs/CODEMAPS/`](docs/CODEMAPS) (system, backend, frontend, data, dependencies) and [`CLAUDE.md`](CLAUDE.md).
+
+### How it works (in one paragraph)
+
+The app is **one binary that runs in two modes**: the GUI process, and — spawned per transfer — a `--transfer-worker` child that runs a single croc send/receive and exits. The subprocess model gives kill-based cancellation, working-directory isolation, and crash isolation. A recovery loop retries dropped transfers with backoff and resumes from a deterministic staging directory, so a flaky link doesn't lose progress. Nearby discovery uses LAN multicast to advertise devices and an ephemeral pinned-TLS channel to hand off the croc code without typing.
+
+## Contributing
+
+- Conventional commit subjects: `feat:` / `fix:` / `refactor:` / `docs:` / `test:` / `chore:` / `perf:` / `ci:`.
+- When you change a Go method exposed to the frontend, regenerate the `wailsjs/` bindings (don't hand-edit them).
+- When you add a UI string, add it to **all** locale files in `frontend/src/locales/`.
+- Releases are cut by pushing a `v*` tag on `main`, which triggers the GitHub Actions build + publish.
 
 ## Key Dependencies
 
-- `github.com/wailsapp/wails/v2` - Cross-platform desktop app framework
-- `github.com/schollz/croc/v10` - Secure P2P file transfer library
-- `github.com/sirupsen/logrus` - Structured logging
-- `github.com/pkg/errors` - Error handling with stack traces
+- [`wailsapp/wails/v2`](https://github.com/wailsapp/wails) — cross-platform desktop framework (webview + Go IPC)
+- [`schollz/croc/v10`](https://github.com/schollz/croc) — secure P2P file transfer
+- [`schollz/peerdiscovery`](https://github.com/schollz/peerdiscovery) — LAN multicast discovery
+- [`sirupsen/logrus`](https://github.com/sirupsen/logrus) — structured logging
+- `svelte` 5 · `vite` 6 · `svelte-i18n` — frontend

--- a/docs/CODEMAPS/architecture.md
+++ b/docs/CODEMAPS/architecture.md
@@ -1,0 +1,56 @@
+<!-- Generated: 2026-06-12 | Files scanned: ~50 | Token estimate: ~750 -->
+# Architecture
+
+Type: single cross-platform desktop app. Wails v2 (Go backend + Svelte 5 webview frontend, one binary). P2P transport = croc.
+
+## Process model — one binary, two modes
+```
+krokodyl(.exe)
+  main.go: isWorkerProcess(os.Args)?
+   ├─ no  → wails.Run(App)            # GUI process (long-lived)
+   └─ yes → runWorker() → exit        # --transfer-worker child (one transfer, then dies)
+```
+Flag check happens BEFORE wails.Run() (Wails never returns).
+
+## Transfer data flow
+```
+UI (App.svelte)
+  └─ Wails binding → App.SendFiles/ReceiveFile (app.go)
+       └─ runRecoverableAttempts (recovery.go)   # retry loop + budget
+            └─ runWorkerJob (app.go)  ──spawn──►  worker subprocess (worker.go)
+                 stdin:  JSON workerJob                 │ croc send/recv
+                 stdout: JSON workerEvent ◄─────────────┘ (progress @200ms)
+            └─ startStallWatchdog (stall.go)            # kill-only on no-bytes
+       └─ tm.update() (transfers.go)  → Wails EventsEmit("transfer:updated")
+  └─ EventsOn("transfer:updated"|"nearby:*"|"transfer:overwrite") → re-render
+```
+
+## Nearby (LAN, zero-code) flow
+```
+discovery.go  multicast :42791  (advertise id/name/ctrlPort/certFP/addrs, 2s)
+   ▼ peer list
+nearby.go     TLS control channel (cert-FP pinned)
+   sender ─ offer(files,size) ─► receiver ─ accept/decline ─► code handoff ─► croc
+netaddr.go    rank real-LAN > virtual; sender tries candidates real-first (4s each)
+```
+
+## Service boundaries (Go, package main, repo root)
+| Concern | Files |
+|---|---|
+| Entry / mode dispatch | main.go |
+| GUI orchestration, Wails API | app.go |
+| Transfer worker (child) | worker.go, cmd/guiharness (stderr-bug harness) |
+| Resilience | recovery.go, stall.go |
+| Transfer state | transfers.go |
+| Resume staging | staging.go |
+| LAN discovery + control | discovery.go, nearby.go, netaddr.go, names.go |
+| Persistence | settings.go, history.go |
+| Frontend | frontend/src |
+
+## Key invariants
+- Terminal transfer states immutable (late events can't resurrect).
+- `stagingDirForCode` deterministic → resume; changing it orphans partials.
+- Worker `cmd.Stderr = nil` (Windows GUI-subsystem dead-handle fix).
+- macOS ad-hoc codesign only (no notarization — hard constraint).
+
+See: [backend.md](backend.md) · [frontend.md](frontend.md) · [data.md](data.md) · [dependencies.md](dependencies.md)

--- a/docs/CODEMAPS/backend.md
+++ b/docs/CODEMAPS/backend.md
@@ -1,0 +1,64 @@
+<!-- Generated: 2026-06-12 | Files scanned: ~27 Go | Token estimate: ~850 -->
+# Backend (Go, package main)
+
+No HTTP server. The "API" is `App` methods bound to the frontend by Wails + an internal stdin/stdout worker protocol.
+
+## Wails-exposed App methods (app.go) → flow
+```
+SendFiles(paths[]) / SendFile / SendToPeer(peerId,paths)
+   → runRecoverableAttempts → runWorkerJob(send) → worker croc-send → tm.update
+ReceiveFile(code,dir)
+   → stagingDirForCode → runRecoverableAttempts → runWorkerJob(recv) → tm.update
+CancelTransfer(id)        → popCancel + killWorker (Process.Kill)
+ResendTransfer(id)        → lookup history → verify files → re-send (peer by MachineID, fallback name)
+RespondToOverwrite(id,ans)→ unblocks worker finalize (answers "transfer:overwrite")
+RespondToNearbyOffer(...) → accept/decline/busy on TLS control channel
+GetTransfers / ClearHistory / GetNearbyPeers / GetNearbyPrefs / SetNearbyVisible(bool)
+SelectFile(s) / SelectDirectory / GetDefaultDownloadPath   # native dialogs
+GetDeviceName / GetBuildStamp
+```
+
+## Worker protocol (worker.go ↔ app.go) — JSON lines
+```
+parent→worker (stdin, then closed):
+  workerJob { mode:"send"|"receive", code, paths[]?, stagingDir? }
+worker→parent (stdout, one JSON/line):
+  workerEvent { type:"files"|"progress"|"done"|"error",
+                files[], size, sent, progress(0-99), speed, message }
+exit 0 = success, 1 = error. progress caps 99; "done" = 100.
+```
+Parent reads with 64KB-line / 1MB-max scanner. Bad JSON line → warn + skip.
+
+## Event emission (Go → frontend, Wails runtime)
+```
+transfer:updated   FileTransfer copy on every state change
+transfer:overwrite overwrite decision request (file conflict)
+nearby:updated     peer list changed
+nearby:state       discovery available / unavailable
+nearby:offer       incoming offer (sender name + addr)
+transfer:cleared   history wiped
+```
+
+## Resilience (recovery.go, stall.go)
+```
+runRecoverableAttempts:
+  loop attempt → runWorkerJob → on err: budget.record(peakPct)
+                 give up if no new peak in N tries
+  backoff = min(2^attempt s, 10s); status "reconnecting" between tries
+  overallProgress(basePct, sessionPct) → bar continues, no 0% reset
+startStallWatchdog: KILL-ONLY. connectGrace (pre-first-byte) vs stall timeout (armed).
+```
+
+## State manager (transfers.go)
+`transferManager`: mutex map, `add` prepends (newest-first), `snapshot`/`reset`, `update` no-op if terminal, emits struct COPIES.
+
+## Key files
+```
+app.go      1187  GUI orchestration, Wails API, recovery glue, history persist
+worker.go    238  child process: croc send/recv + 200ms progress poller
+discovery.go 405  multicast advertise/listen, liveness, hide/unhide Gen
+nearby.go    377  TLS control server/client, fingerprint pinning, offer/accept
+staging.go   156  deterministic stagingDirForCode, validateRelPath, moveStagedFile (EXDEV copy fallback)
+settings.go  159  settings.json, MachineID, partial sweep
+recovery.go   80 · stall.go 69 · transfers.go 133 · netaddr.go 101 · history.go 74 · names.go 41 · main.go 137
+```

--- a/docs/CODEMAPS/data.md
+++ b/docs/CODEMAPS/data.md
@@ -1,0 +1,50 @@
+<!-- Generated: 2026-06-12 | Files scanned: settings/history + protocols | Token estimate: ~650 -->
+# Data: State & Protocols
+
+No database. State = two JSON files on disk + several on-wire protocols.
+
+## On-disk (OS config dir, mode 0o600)
+```
+settings.json (settings.go)
+  LastDestination, LastPeer, MachineID(uuid, stable per-install),
+  NearbyVisible(*bool — nil=never set, default visible),
+  partials[]{ Code, Dir, At }      # for resume; swept after partialMaxAge 24h
+
+history.json (history.go)
+  []FileTransfer  — terminal only, cap 50 (maxHistoryEntries), newest-first
+  Code + Speed STRIPPED on save (security/size). ResumeCode kept (internal).
+```
+Load: app.go reverses oldest-first file → `tm.add` prepends → newest-first UI.
+Writes serialized by `historyMu`. `sweepPartials` deletes only basenames starting `partialDirPrefix`.
+
+## FileTransfer (transfers.go → models.ts)
+```
+id(send*/receive*), name, files[], size, progress, speed,
+status: waiting|preparing|sending|receiving|reconnecting|completed|error|cancelled,
+code?, peer?, error?, resendable?, paths[]?, peerMachineId?, resumeCode?
+```
+
+## Worker protocol (process-local, stdin/stdout JSON)
+```
+job   { mode, code, paths[]?, stagingDir? }
+event { type:files|progress|done|error, files[], size, sent, progress, speed, message }
+```
+
+## Discovery payload (UDP multicast :42791, every 2s)
+```
+{ id, name, controlPort, certFingerprint(sha256), addresses[≤8], machineId? }
+expiry 5s · self-echo health check · hide via Gen counter + 3s bye-suppression
+```
+
+## Nearby control channel (TLS, ephemeral self-signed ECDSA P-256)
+```
+cert FINGERPRINT-PINNED against discovery payload (no CA).
+offer{senderName,files[≤512B name],size(≤64KiB msg)} → accept|decline|busy → croc code
+addresses ranked real-LAN(192.168/10) > virtual(172.16/Hyper-V/WSL); 4s/candidate, 75s total
+```
+
+## croc (transport)
+Code-phrase PAKE; relay + LAN; resume via pre-allocated staging files + `utils.MissingChunks`.
+
+## Migrations
+None. JSON is schema-on-read; no version field. ⚠ `stagingDirForCode` hash change = breaking (orphans partials).

--- a/docs/CODEMAPS/dependencies.md
+++ b/docs/CODEMAPS/dependencies.md
@@ -1,0 +1,38 @@
+<!-- Generated: 2026-06-12 | Files scanned: go.mod + package.json | Token estimate: ~550 -->
+# Dependencies
+
+## External services
+None hosted by this project. Transport uses croc's relay (public `croc.schollz.com` by default) + direct LAN. No DB, no cloud, no telemetry.
+
+## Go (go 1.25.0 — direct requires)
+```
+github.com/wailsapp/wails/v2   v2.12.0  desktop shell (webview + IPC). CLI ver MUST match.
+github.com/schollz/croc/v10    v10.4.4  P2P transfer (PAKE, relay, chunked resume)
+github.com/schollz/peerdiscovery v1.7.6 LAN multicast discovery (:42791)
+github.com/sirupsen/logrus     v1.9.4   structured logging (file sink)
+github.com/google/uuid         v1.6.0   MachineID / transfer ids
+```
+Notable indirect (via croc): pake/v3 (PAKE), go-qrcode, machineid, progressbar. crypto/tls + crypto/ecdsa (stdlib) for the nearby control channel.
+
+## Frontend (npm)
+```
+dep:    svelte-i18n            ^4.0.1   6-locale i18n
+devDep: svelte                 ^5.36.7  runes
+        vite                   ^6.3.5   bundler/dev server
+        @sveltejs/vite-plugin-svelte ^5.1.1
+        typescript             ^5.9.3
+        svelte-check           ^4.3.0   type + a11y gate (npm run check)
+        svelte-preprocess, tslib
+```
+
+## Build / CI toolchain
+```
+Wails CLI  v2.12.0 (pinned in .github/workflows/release.yml — sync w/ go.mod)
+GitHub Actions matrix: ubuntu + windows + macos, Node 22
+Linux system deps: gcc, libgtk-3-dev, libwebkit2gtk-4.1-dev  (→ -tags webkit2_41)
+macOS: ad-hoc codesign (--sign -) + ditto zip. NO notarization (no Apple Dev acct).
+Release trigger: push v* tag → build all 3 → softprops/action-gh-release.
+```
+
+## Generated (do not edit)
+`frontend/wailsjs/**` — Wails-generated Go↔TS bindings; regenerate on Go struct change.

--- a/docs/CODEMAPS/frontend.md
+++ b/docs/CODEMAPS/frontend.md
@@ -1,0 +1,52 @@
+<!-- Generated: 2026-06-12 | Files scanned: 17 src | Token estimate: ~700 -->
+# Frontend (Svelte 5 + TS + Vite 6)
+
+SPA bundled into the Go binary. Svelte 5 runes (`$state`/`$derived`), no Redux/Pinia.
+
+## Component tree
+```
+main.ts  mount(App, #app)
+└─ App.svelte (1602 lines — most UI/state here)
+   ├─ TitleBar.svelte        brand · ThemeSwitcher · lang <select>
+   │   └─ Windows: native chrome strip (min/max/close, --wails-draggable)
+   │   └─ macOS: traffic-light padding
+   ├─ ThemeSwitcher.svelte   ☀️/🌙 toggle
+   ├─ Tabs: Send | Receive   (ARIA tablist, roving tabindex)
+   │   Send:    code spotlight · nearby peer list · visibility toggle
+   │   Receive: code input (no auto-submit) · destination picker
+   ├─ Transfer list          status badge · progress bar · cancel/resend
+   └─ Modals (use:modalDialog focus-trap): overwrite · nearby offer · clear-history
+   └─ Toast (role=alert/status, aria-live)
+```
+
+## State
+```
+$state   transfers, nearbyPeers, activeTab, modals, toast, nearbyVisible, buildStamp
+$derived waitingSend, sortedPeers
+stores/theme.ts  custom writable → localStorage + prefers-color-scheme; class on <html>
+```
+
+## Backend bridge (generated — DO NOT edit wailsjs/)
+```
+calls:   import { SendFiles, ReceiveFile, ... } from wailsjs/go/main/App
+events:  EventsOn(name, cb) from wailsjs/runtime/runtime
+models:  wailsjs/go/models.ts  FileTransfer · NearbyPeer · NearbyPrefs · ResendOutcome
+```
+Subscribed events: `transfer:updated`, `transfer:overwrite`, `nearby:updated`, `nearby:state`, `nearby:offer`, `transfer:cleared`.
+
+## Data flow
+```
+user action → await App.method() → state update
+backend EventsEmit → EventsOn handler → state update → $derived recompute → re-render
+```
+
+## i18n (i18n.ts, svelte-i18n)
+6 locales `src/locales/*.json`: en nl fr es hu zh. Auto-detect system locale, fallback en. Override via TitleBar `bind:value={$locale}`.
+
+## Styling (style.css)
+Global CSS vars; light = warm paper, dark = graphite (primary croc-green #2FBF8F). Fluid `clamp()` type; breakpoints <480/<380px & <560px height. `.sr-only`, global `:focus-visible`, WCAG 2.1 AA.
+
+## Gotchas
+- Direction by id prefix `send`/`receive`.
+- `EventsOn`/toast timers not cleaned on destroy.
+- File paths platform-specific (`\` vs `/`).


### PR DESCRIPTION
- README: rewritten for first-time repo users — Features (nearby, resilient resume, resend, a11y), Prerequisites, run/build/test commands, two-machine + GUI-launched testing caveats, project layout, "how it works", Contributing. Fixes stale content (Svelte 3 → 5, "no test commands", outdated architecture).
- CLAUDE.md: project guide for Claude Code — commands, architecture, frontend conventions, gotchas/constraints, release flow.
- docs/CODEMAPS/: token-lean architecture maps (architecture/backend/frontend/ data/dependencies) + .reports/codemap-diff.txt scan summary.
- .claude/skills/krokodyl-patterns: repo skill from git co-change analysis.
- .gitignore: ignore personal .claude.local.md.